### PR TITLE
Add Updraft Helicity to GRIB table.

### DIFF
--- a/gdal/frmts/grib/degrib18/degrib/metaname.cpp
+++ b/gdal/frmts/grib/degrib18/degrib/metaname.cpp
@@ -863,6 +863,9 @@ static const GRIB2ParmTable MeteoStability[] = {
 /* 10 */   {"LFTX", "Surface lifted index", "K", UC_NONE},
 /* 11 */   {"4LFTX", "Best (4-layer) lifted index", "K", UC_NONE},
 /* 12 */   {"RI", "Richardson number", "-", UC_NONE},
+/* 13 */   {"SHWINX", "Showalter Index", "K", UC_NONE},
+/* 14 */
+/* 15 */   {"UPHL", "Updraft Helicity", "m^2/s^-2", UC_NONE},
 };
 
 /* GRIB2 Code table 4.2 : 0.13 */


### PR DESCRIPTION
Our new WRF is spitting out UPHL but we can't extract it because of GDAL's aging GRIB2 tables.