### PR TITLE
UPHL index out of order, dummy.

### DIFF
--- a/gdal/frmts/grib/degrib18/degrib/metaname.cpp
+++ b/gdal/frmts/grib/degrib18/degrib/metaname.cpp
@@ -864,7 +864,7 @@ static const GRIB2ParmTable MeteoStability[] = {
 /* 11 */   {"4LFTX", "Best (4-layer) lifted index", "K", UC_NONE},
 /* 12 */   {"RI", "Richardson number", "-", UC_NONE},
 /* 13 */   {"SHWINX", "Showalter Index", "K", UC_NONE},
-/* 14 */
+/* 14 */   {"RES", "Reserved", "", UC_NONE},
 /* 15 */   {"UPHL", "Updraft Helicity", "m^2/s^-2", UC_NONE},
 };
 


### PR DESCRIPTION
By skipping 14, the UPHL index became 14 instead of 15 as needed. This fixes that.

Band 329 Block=354x1 Type=Float64, ColorInterp=Undefined
  Description = 2000-5000[m] HTGL="Specified height level above ground"
  Metadata:
    GRIB_COMMENT=Updraft Helicity [m^2/s^-2]
    GRIB_ELEMENT=UPHL
    GRIB_FORECAST_SECONDS=86400 sec
    GRIB_PDS_PDTN=0
    GRIB_PDS_TEMPLATE_NUMBERS=7 15 2 0 116 0 0 0 0 0 0 5 160 103 0 0 0 7 208 103 0 0 0 19 136
    GRIB_REF_TIME=  1512604800 sec UTC
    GRIB_SHORT_NAME=2000-5000-HTGL
    GRIB_UNIT=[m^2/s^-2]
    GRIB_VALID_TIME=  1512691200 sec UTC